### PR TITLE
fix(wheel): close BTC lifecycle and broaden Monthly P&L gate (#40)

### DIFF
--- a/src/trades/legs.ts
+++ b/src/trades/legs.ts
@@ -1000,7 +1000,7 @@ export function determineTradeLifecycleStatus(
     }
 
     if (hasAssignmentEvent && hasOpenStockPosition) {
-        result.status = 'Open';
+        result.status = 'Assigned';
         result.exitReason = null;
         return result;
     }

--- a/src/trades/legs.ts
+++ b/src/trades/legs.ts
@@ -1189,10 +1189,12 @@ export function enrichTradeData(
         expirationDate = pmccShortExpiration;
     }
 
-    if (!this.isPmccTrade(enriched) && this.isWheelOrPmccTrade(enriched) && pmccShortExpiration) {
+    if (!this.isPmccTrade(enriched) && this.isWheelOrPmccTrade(enriched)) {
         const hasActiveOptions = this.hasNetOpenOptionLegs({ ...enriched, legs: legSummary.legs });
-        if (hasActiveOptions) {
+        if (hasActiveOptions && pmccShortExpiration) {
             expirationDate = pmccShortExpiration;
+        } else if (!hasActiveOptions && this.getTradeOpenStockShares(enriched) > 0) {
+            expirationDate = null;
         }
     }
 

--- a/src/ui/charts/dashboard-charts.ts
+++ b/src/ui/charts/dashboard-charts.ts
@@ -670,15 +670,12 @@ export function updateMonthlyPLChart(this: DashboardChartsContext): void {
     };
 
     this.trades.forEach(trade => {
-        // Include fully-realized trades (closed/expired/assigned-no-options) plus
-        // in-flight assigned wheels (assigned + still has open covered calls).
-        const isFullyRealized = this.isFullyRealizedTrade(trade);
-        const isInFlightAssigned = !isFullyRealized
-            && String(trade.status || '').toLowerCase() === 'assigned'
-            && this.isWheelOrPmccTrade(trade);
-        if (!isFullyRealized && !isInFlightAssigned) return;
-
         const legs = Array.isArray(trade.legs) ? trade.legs as Record<string, unknown>[] : [];
+        const hasOptionLegs = legs.some(leg => {
+            const t = String(leg.type || '').toUpperCase().trim();
+            return t === 'CALL' || t === 'PUT';
+        });
+        if (!hasOptionLegs) return;
 
         // Step 1: Attribute each option leg's cashflow to its execution month (cash-basis).
         // STO credit lands in the month the option was sold; BTC debit in the month


### PR DESCRIPTION
## Summary

Fixes #40. Three small, connected edits across two files:

- **`src/trades/legs.ts` (lifecycle status)** — In `determineTradeLifecycleStatus`, the `hasAssignmentEvent && hasOpenStockPosition` branch now returns `'Assigned'` instead of `'Open'`. The previous `'Open'` status silently dropped the trade from `updateMonthlyPLChart`'s `isInFlightAssigned` gate (which expects lowercase `'assigned'`) and from realized-PL aggregation. `isFullyRealizedTrade`'s `isPromotedToOpen` branch already re-routes assigned wheels with active CC back to unrealized handling, so both sub-states resolve correctly.
- **`src/trades/legs.ts` (enrichment)** — In `enrichTradeData`, the wheel branch now clears `expirationDate` when there are no net-open option legs but stock is still held. After BTC of the covered call, DTE no longer renders the stale "this Friday" and Strike no longer shows the closed call's `C` label (`summarizeLegs` already falls back to the stock leg as `primaryLeg`).
- **`src/ui/charts/dashboard-charts.ts` (Monthly P&L gate)** — `updateMonthlyPLChart` now includes any trade that has at least one option leg, regardless of overall status. The per-leg cash-basis loop is correct independent of trade status (each leg's cash flow is attributed to its `executionDate` month). The stock-PL branch is still gated by `isClosedStatus`, so non-closed trades only contribute option cashflows. This also incidentally fixes rolled CSPs (`'Rolling'` status) whose leg cashflows were being dropped from the chart.

No schema changes, no new modules, no new dependencies. Spec: `docs/superpowers/specs/2026-06-04-wheel-btc-lifecycle-fix-design.md`. Plan: `docs/superpowers/plans/2026-06-04-wheel-btc-lifecycle-fix.md`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:strict` clean (both `src/trades/` and `src/ui/` are strict subprojects)
- [ ] Manual: build a wheel trade (STO PUT → assign → BTO stock → STO CC → BTC CC); after BTC, status reads **Assigned**, DTE blank, Strike blank
- [ ] Manual: Monthly P&L chart shows the STO CALL credit in its execution month and the BTC debit in its execution month
- [ ] Manual: roll a CSP (STC + STO into next expiration); both legs land in their execution months on the Monthly P&L chart
- [ ] Regression: closed wheels — Monthly P&L bars unchanged from before
- [ ] Regression: active-CC wheel (assigned + open CC) — Strike/DTE still show the CALL leg; unrealized P&L renders via `isPromotedToOpen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)