### PR TITLE
fix: post-2.2.3 verification fixes (Gemini wiring, credit playbook, banner)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,7 @@ directly from grid callbacks.
 ### Gemini AI Coach (`src/ai/gemini-agent.ts`)
 
 - User-provided API key stored encrypted in `localStorage`
-- Allowed models: `gemini-2.5-flash-lite`, `gemini-2.5-flash` (default), `gemini-2.5-pro`
+- Allowed models: `gemini-3.1-flash-lite`, `gemini-3.5-flash` (default), `gemini-3.1-pro-preview`
 - Sends `mcpContext` snapshot + query to the Gemini generateContent endpoint
 - Response shape validated with `isGeminiApiResponse()` before any field access
 - Falls back to `LocalInsightsAgent` on any network/API failure

--- a/index.html
+++ b/index.html
@@ -608,14 +608,14 @@
                 </div>
             </div>
 
-	            <!-- Credit Playbook View -->
-	            <div class="view credit-playbook-view">
-	                <header class="credit-playbook-header">
-	                    <div class="credit-playbook-metrics" id="credit-playbook-metrics" aria-live="polite"></div>
-	                    <div class="credit-playbook-detail-meta credit-playbook-help">
-	                        Wheel trades: Credit Playbook tracks option premium legs. Total wheel P&amp;L (including stock assignment/sale) is shown in All Trades and Dashboard → Wheel/PMCC tracker.
-	                    </div>
-	                </header>
+            <!-- Credit Playbook View -->
+            <div class="view credit-playbook-view">
+                <header class="credit-playbook-header">
+                    <div class="credit-playbook-metrics" id="credit-playbook-metrics" aria-live="polite"></div>
+                    <div class="credit-playbook-detail-meta credit-playbook-help">
+                        Wheel trades: Credit Playbook tracks option premium legs. Total wheel P&amp;L (including stock assignment/sale) is shown in All Trades and Dashboard → Wheel/PMCC tracker.
+                    </div>
+                </header>
 
                 <section class="credit-playbook-controls" aria-label="Credit playbook filters">
                     <div class="credit-playbook-filter">
@@ -818,11 +818,7 @@
                             </div>
                             <div class="form-group">
                                 <label for="gemini-model" class="form-label">Model</label>
-                                <select id="gemini-model" class="form-control">
-                                    <option value="gemini-2.5-flash-lite">Gemini 2.5 Flash Lite</option>
-                                    <option value="gemini-2.5-flash">Gemini 2.5 Flash</option>
-                                    <option value="gemini-2.5-pro">Gemini 2.5 Pro</option>
-                                </select>
+                                <select id="gemini-model" class="form-control"></select>
                             </div>
                             <p class="settings-help-text">Keys stay on this device. Use Google AI Studio or any compatible service exposing the Gemini generateContent API.</p>
                             <div class="gemini-status" id="gemini-status" role="status">Not set</div>
@@ -964,7 +960,7 @@
         (function () {
             const cfg = window.ANNOUNCEMENT_BANNER_CONFIG;
             const container = document.getElementById('announcement-banner');
-            if (!cfg || !cfg.enabled || !container) {
+            if (!cfg || !cfg.enabled || !cfg.html || !container) {
                 if (container) container.remove();
                 document.documentElement.style.setProperty('--app-top-offset', '0px');
                 return;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -7,7 +7,7 @@
 export const GEMINI_MODELS = [
     { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash Lite' },
     { id: 'gemini-3.5-flash',      label: 'Gemini 3.5 Flash' },
-    { id: 'gemini-3.1-pro',        label: 'Gemini 3.1 Pro' },
+    { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro (Preview)' },
 ] as const
 
 export type GeminiModel = typeof GEMINI_MODELS[number]['id']

--- a/src/integrations/gemini.ts
+++ b/src/integrations/gemini.ts
@@ -52,12 +52,11 @@ export function initializeGeminiControls(this: any) {
     }
 
     if (modelSelect) {
-        const options = Array.from(modelSelect.options).map(option => option.value);
-        if (options.length === 0) {
-            GEMINI_ALLOWED_MODELS.forEach(model => {
+        if (modelSelect.options.length === 0) {
+            GEMINI_MODELS.forEach(({ id, label }) => {
                 const option = document.createElement('option');
-                option.value = model;
-                option.textContent = model.replace(/gemini-2\.5-/, 'Gemini 2.5 ').replace(/-/g, ' ').replace(/\b([a-z])/g, (_, letter) => letter.toUpperCase());
+                option.value = id;
+                option.textContent = label;
                 modelSelect.appendChild(option);
             });
         }

--- a/src/trades/spreads.ts
+++ b/src/trades/spreads.ts
@@ -213,7 +213,7 @@ export function extractSingleSpread(
         spreadStrike = '—';
     }
 
-    let totalGrossPremium = 0, totalFees = 0, entryDateMs: number | null = null, exitDate: Date | null = null, quantity = 0;
+    let totalGrossPremium = 0, totalFees = 0, entryDateMs: number | null = null, exitDate: Date | null = null;
 
     openingLegs.forEach(leg => {
         const legAction = this.getLegAction(leg);
@@ -223,7 +223,6 @@ export function extractSingleSpread(
         const direction = legAction === 'SELL' ? 1 : -1;
         totalGrossPremium += direction * legPremium * multiplier * legQuantity;
         totalFees += Number(leg.fees) || 0;
-        quantity = Math.max(quantity, Math.abs(Number(leg.quantity) || 0));
         const legDate = this.parseDateValue(leg.executionDate);
         if (legDate && (entryDateMs === null || legDate.getTime() < entryDateMs)) entryDateMs = legDate.getTime();
     });
@@ -261,7 +260,8 @@ export function extractSingleSpread(
         : null;
 
     const multiplier = 100;
-    const pricePerContract = displayQuantity > 0 ? totalGrossPremium / (displayQuantity * multiplier) : 0;
+    // Per-contract entry premium uses opening quantity so partial closes don't inflate the displayed price.
+    const pricePerContract = openingQuantity > 0 ? totalGrossPremium / (openingQuantity * multiplier) : 0;
 
     let width = 0;
     if (type === 'CALL/PUT' && strikes.length >= 4) {
@@ -605,7 +605,8 @@ export function extractSingleLegPair(
 
     const expirationDate = this.parseDateValue(expiration);
     const hasExpired = expirationDate && expirationDate < now;
-    const isOpen = openingLegs.length > 0 && closingLegs.length === 0 && !hasExpired && !isTradeClosed;
+    // A partially closed single-leg position is still active while contracts remain.
+    const isOpen = netQuantity > 0 && !hasExpired && !isTradeClosed;
 
     if (netQuantity === 0 && !isOpen) {
         netQuantity = Math.abs(openingLegs.reduce((sum, leg) => {

--- a/src/ui/credit-playbook/data.ts
+++ b/src/ui/credit-playbook/data.ts
@@ -16,6 +16,7 @@ interface CreditPlaybookDataContext {
   currentDate: Date | unknown
   creditPlaybookSort?: { key: string; direction: string }
   isClosedStatus(status: unknown): boolean
+  isAssignedStatus(status: unknown): boolean
   extractSpreadPair(trade: TradeRecord, legs: unknown[], now: Date, pairs: LegPair[]): void
   extractIndividualLegPairs(trade: TradeRecord, legs: unknown[], now: Date, pairs: LegPair[]): void
   applyCreditPlaybookSortIndicators(): void
@@ -131,7 +132,7 @@ export function extractCreditPlaybookLegPairs(
             this.extractIndividualLegPairs(trade, legs, now, pairs);
         }
 
-        if (this.isClosedStatus(trade.status)) {
+        if (this.isClosedStatus(trade.status) || this.isAssignedStatus(trade.status)) {
             reconcileClosedTradePL(trade, pairs.slice(tradePairsStart));
         }
     });


### PR DESCRIPTION
## Summary

Audit of all functional changes landed since `2.2.3` (19 commits, 10 files). Fixes the regressions found. MCP server verified separately — fully compatible with schema 2.5 and the wheel BTC lifecycle change in PR #42 (8/8 pytest, ruff clean, real 115-trade DB loads with all probed tools returning sane data).

### Gemini API wiring (CRITICAL)

`dee5afa` updated `GEMINI_MODELS` to the 3.x family but left the wiring inconsistent:

- **`gemini-3.1-pro` is not a real Gemini API ID** — only `gemini-3.1-pro-preview` is documented at https://ai.google.dev/gemini-api/docs/models. The other two (`gemini-3.1-flash-lite`, `gemini-3.5-flash`) are valid. Corrected `GEMINI_MODELS` accordingly.
- **`index.html` still hardcoded `<option value="gemini-2.5-*">`** in the Settings dropdown, so any user opening Settings would pick a stale 2.5 ID and the API would 404. Emptied the `<select>` so `initializeGeminiControls()` populates it from `GEMINI_MODELS`.
- **`initializeGeminiControls()` built option labels via a `gemini-2.5-` regex** — would have produced garbled labels for the 3.x family once the HTML was fixed. Now uses the `label` field from `GEMINI_MODELS` directly.
- **`AGENTS.md` still documented the 2.5 IDs** — agents reading this file would have written wrong code. Synced to the runtime allow-list.

### Credit Playbook (IMPORTANT)

- **`extractSingleLegPair` partial-close gate**: `isOpen` was `openingLegs.length > 0 && closingLegs.length === 0 && …`, so ANY BTC leg on a single-leg strategy (CSP, naked call/put) flipped the playbook row to Closed even when contracts remained open. Switched to `netQuantity > 0`, matching the `extractSingleSpread` pattern.
- **`reconcileClosedTradePL` outer gate**: previously fired only for `Closed`/`Expired` statuses. With the wheel BTC fix in PR #42, more trades will sit at `'Assigned'`. Reconcile is already internally guarded by `hasRealizedStockLegs || isAssignmentCycle` and produces ~0 adjustment for in-flight wheels (since `calculatePL` returns option-only cashflow for Assigned status), so widening to also fire for `'Assigned'` is safe and catches the manual-status-override edge case for fully-settled assigned wheels.
- **`extractSingleSpread` cleanups**: removed dead `quantity` variable (shadowed by `openingQuantity`); compute `pricePerContract` from `openingQuantity` so partial closes don't inflate the displayed per-contract entry price.

### Banner (MINOR)

- Guard `cfg.html` to prevent rendering `<span>undefined</span>` if the config object is misconfigured in the future.
- Restored consistent space indentation on the Credit Playbook view header (drifted to tabs in a prior edit).

### Out of scope

- **Wheel BTC lifecycle fix** — covered by PR #42.
- **Storage migration for users with `gemini-2.5-*` in localStorage** — `setGeminiModel` already coerces unknown IDs to `DEFAULT_GEMINI_MODEL` at load (`src/integrations/gemini.ts:50-52`), so no migration is needed. Stale localStorage value is silently upgraded the next time `saveGeminiConfigToStorage()` runs.
- **Cross-layer import**: `GeminiModel` type in `src/types/common.ts` re-exports from `@core/config`, inverting the types→config layering. Flagged as MINOR; not addressed in this PR to avoid scope creep.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run typecheck:strict` clean (all 8 subprojects)
- [x] MCP server: pytest (8 passed) + ruff clean + real DB load succeeded
- [ ] Manual: Settings → AI Coach. Confirm the Model dropdown lists exactly **Gemini 3.1 Flash Lite**, **Gemini 3.5 Flash** (default selected), **Gemini 3.1 Pro (Preview)** — no `Gemini 2.5 *` options
- [ ] Manual: paste a real Gemini API key, save, run the AI Coach against any open position. Confirm it returns a response (no 404 from `gemini-3.1-pro-preview`)
- [ ] Manual: open or build a Cash-Secured Put with 3 contracts. Close 1. Open Credit Playbook. Trade should appear in the **Active** filter with quantity = 2 remaining (not in Closed)
- [ ] Manual: dashboard banner renders correctly with the existing config; sidebar height unchanged
- [ ] Regression: All Trades + Dashboard render without errors after switching branches

## Related

- PR #42 — fix(wheel): close BTC lifecycle and broaden Monthly P&L gate (#40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)